### PR TITLE
feat(navigation.js): 将“回到主站”的链接改成真正的主页

### DIFF
--- a/cyrillic/gaunt-mongolian/navigation.js
+++ b/cyrillic/gaunt-mongolian/navigation.js
@@ -17,7 +17,7 @@ var addNavLinks = function () {
             document.body.insertBefore(topNavigation, document.body.firstChild);
         }
         backToMainLink.setAttribute('class', 'topnavlink');
-        backToMainLink.href = "/cyrillic/";
+        backToMainLink.href = "/";
         backToMainLink.innerHTML = "回到主站";
         topNavigation.insertBefore(backToMainLink, topNavigation.firstChild);
     }


### PR DESCRIPTION
将页面顶部链接“回到主站”的地址改成 https://mongol-surah.github.io/  
我不清楚为什么 github 显示的差异有这么多，我对照了一下，确实只改了链接那一行… 😂